### PR TITLE
fix add support for seek in virtual files

### DIFF
--- a/virtual_file.go
+++ b/virtual_file.go
@@ -2,6 +2,7 @@ package packr
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"time"
 )
@@ -10,21 +11,21 @@ var virtualFileModTime = time.Now()
 var _ File = virtualFile{}
 
 type virtualFile struct {
-	*bytes.Buffer
+	*bytes.Reader
 	Name string
 	info fileInfo
 }
 
-func (v virtualFile) FileInfo() (os.FileInfo, error) {
-	return v.info, nil
+func (f virtualFile) FileInfo() (os.FileInfo, error) {
+	return f.info, nil
 }
 
 func (f virtualFile) Close() error {
 	return nil
 }
 
-func (f virtualFile) Seek(offset int64, whence int) (int64, error) {
-	return 0, nil
+func (f virtualFile) Write(p []byte) (n int, err error) {
+	return 0, fmt.Errorf("Not implemented")
 }
 
 func (f virtualFile) Readdir(count int) ([]os.FileInfo, error) {
@@ -37,7 +38,7 @@ func (f virtualFile) Stat() (os.FileInfo, error) {
 
 func newVirtualFile(name string, b []byte) File {
 	return virtualFile{
-		Buffer: bytes.NewBuffer(b),
+		Reader: bytes.NewReader(b),
 		Name:   name,
 		info: fileInfo{
 			Path:     name,


### PR DESCRIPTION
Use bytes.Reader instead of bytes.Buffer in virtual files to support seek.

Hi,
Font awesome fonts in my project were not loading, so I looked at the source and found in https://golang.org/src/net/http/fs.go in serveContent that it uses Seek after reading some part of file to determine content type. So this pull request replaces bytes.Buffer with bytes.Reader to support seek. This fixes my font loading issue. It comes at the cost of not supporting write but I do not think that is needed.
Regards,
Domen