### PR TITLE
Ensure resources are fetch from inside the box

### DIFF
--- a/box_test.go
+++ b/box_test.go
@@ -67,3 +67,9 @@ func Test_List_Physical(t *testing.T) {
 	actual := testBox.List()
 	r.Equal(mustHave, actual)
 }
+
+func Test_Outside_Box(t *testing.T) {
+	r := require.New(t)
+	_, err := testBox.MustString("../README.md")
+	r.Error(err)
+}

--- a/packr.go
+++ b/packr.go
@@ -1,10 +1,10 @@
 package packr
 
 import (
-	"encoding/json"
-	"sync"
 	"bytes"
 	"compress/gzip"
+	"encoding/json"
+	"sync"
 )
 
 var gil = &sync.Mutex{}


### PR DESCRIPTION
* Prevent resources to be found from outside the scope of a box, so they
can't be available in the final box.