### PR TITLE
Fix packr.Box when used as http.Filesystem

### DIFF
--- a/box.go
+++ b/box.go
@@ -117,7 +117,9 @@ func (b Box) find(name string) (File, error) {
 			return newVirtualFile(cleanName, bb), nil
 		}
 		if filepath.Ext(cleanName) != "" {
-			return nil, errors.Errorf("could not find virtual file: %s", cleanName)
+			// The Handler created by http.FileSystem checks for those errors and
+			// returns http.StatusNotFound instead of http.StatusInternalServerError.
+			return nil, os.ErrNotExist
 		}
 		return newVirtualDir(cleanName), nil
 	}
@@ -128,7 +130,7 @@ func (b Box) find(name string) (File, error) {
 	if f, err := os.Open(p); err == nil {
 		return physicalFile{f}, nil
 	}
-	return nil, errors.Errorf("could not find %s in box %s", cleanName, b.Path)
+	return nil, os.ErrNotExist
 }
 
 type WalkFunc func(string, File) error

--- a/http_box_test.go
+++ b/http_box_test.go
@@ -25,6 +25,22 @@ func Test_HTTPBox(t *testing.T) {
 	r.Equal("hello world!\n", res.Body.String())
 }
 
+func Test_HTTPBox_NotFound(t *testing.T) {
+	r := require.New(t)
+
+	mux := http.NewServeMux()
+	mux.Handle("/", http.FileServer(testBox))
+
+	req, err := http.NewRequest("GET", "/notInBox.txt", nil)
+	r.NoError(err)
+
+	res := httptest.NewRecorder()
+
+	mux.ServeHTTP(res, req)
+
+	r.Equal(404, res.Code)
+}
+
 func Test_HTTPBox_Handles_IndexHTML(t *testing.T) {
 	r := require.New(t)
 


### PR DESCRIPTION
The handler created by `http.FileSystem` checks for `NotFound` related errors and returns `http.StatusNotFound` instead of `http.StatusInternalServerError`.

You can find the corresponding code [here](https://github.com/golang/go/blob/master/src/net/http/fs.go#L623).