### PR TITLE
Also match Go version 1.9 next to 1.9.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    condition: $TRAVIS_GO_VERSION =~ ^1\.9\.[0-9]+$
+    condition: $TRAVIS_GO_VERSION =~ ^1\.9(|\.[0-9]+)$


### PR DESCRIPTION
It seems that Travis' Go Version is 1.9 but we only matched against 1.9.x. 
This change makes the last part of the version optional and Travis should pick up the deploy step when a release is tagged.

Closes #25 