### PR TITLE
rfc: error on virtual directory that does not exist

### DIFF
--- a/box_test.go
+++ b/box_test.go
@@ -61,12 +61,12 @@ func Test_Box_Walk_Virtual(t *testing.T) {
 		return nil
 	})
 	r.NoError(err)
-	r.Equal(3, count)
+	r.Equal(4, count)
 }
 
 func Test_List_Virtual(t *testing.T) {
 	r := require.New(t)
-	mustHave := []string{"a", "b", "c"}
+	mustHave := []string{"a", "b", "c", "d/a"}
 	actual := virtualBox.List()
 	sort.Strings(actual)
 	r.Equal(mustHave, actual)
@@ -114,4 +114,12 @@ func Test_Box_find(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_Virtual_Directory_Not_Found(t *testing.T) {
+	r := require.New(t)
+	_, err := virtualBox.find("d")
+	r.NoError(err)
+	_, err = virtualBox.find("does-not-exist")
+	r.Error(err)
 }

--- a/packr_test.go
+++ b/packr_test.go
@@ -14,6 +14,7 @@ func init() {
 	PackBytes(virtualBox.Path, "a", []byte("a"))
 	PackBytes(virtualBox.Path, "b", []byte("b"))
 	PackBytes(virtualBox.Path, "c", []byte("c"))
+	PackBytes(virtualBox.Path, "d/a", []byte("d/a"))
 }
 
 func Test_PackBytes(t *testing.T) {


### PR DESCRIPTION
On the first call to find(), index the directories in the box.
When returning a virtual directory, first check to see if that
directory exists, if not return a not found error.

This will cause http.FileServer to return a 404 on a
directory that does not exist in the box.

Note: The directory index is delayed until the first find() to make it work with the virtualBox used in testing, as well as to get around any race conditions of init methods.