### PR TITLE
Remove buffalo/render dependency

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -1,9 +1,6 @@
 package example
 
 import (
-	"fmt"
-
-	"github.com/gobuffalo/buffalo/render"
 	"github.com/gobuffalo/packr"
 )
 
@@ -22,10 +19,7 @@ func init() {
 	foo("/templates", packr.NewBox("./templates"))
 	packr.NewBox("./assets")
 
-	r := render.New(render.Options{
-		TemplatesBox: packr.NewBox("./bar"),
-	})
-	fmt.Println(r)
+	packr.NewBox("./bar")
 
 	s := S{}
 	s.f(packr.NewBox("./sf"))


### PR DESCRIPTION
## Overview

When you run `go get -u github.com/gobuffalo/packr/...` on a server that does not have the `gcc` compiler installed the go get will fail with the error below. This is because `github.com/gobuffalo/buffalo/render` has a dependency on it. If you run `go list -f '{{ .Deps }}' github.com/gobuffalo/buffalo/render ` you can see it in the output.

```shell
# github.com/mattn/go-sqlite3
exec: "gcc": executable file not found in $PATH
```
This makes it hard to install from source on a ci servers that do not need the `gcc` compiler at all. Since it is only for the example folder I think it is okay to modify it not to break this. 
