### PR TITLE
Fix relative path finding (gobuffalo/buffalo#982)

### DIFF
--- a/box.go
+++ b/box.go
@@ -158,7 +158,10 @@ func (b Box) Walk(wf WalkFunc) error {
 			return errors.WithStack(err)
 		}
 		return filepath.Walk(base, func(path string, info os.FileInfo, err error) error {
-			cleanName := strings.TrimPrefix(path, base)
+			cleanName, err := filepath.Rel(base, path)
+			if err != nil {
+				cleanName = strings.TrimPrefix(path, base)
+			}
 			cleanName = filepath.ToSlash(filepath.Clean(cleanName))
 			cleanName = strings.TrimPrefix(cleanName, "/")
 			cleanName = filepath.FromSlash(cleanName)


### PR DESCRIPTION
strings.TrimPrefix can give the wrong result with case-insensitive
paths. filepath.Rel usually works better.