### PR TITLE
Added .idea directory to base names skipped by Builder's Run() method

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -39,7 +39,7 @@ func (b *Builder) Run() error {
 		}
 
 		base := filepath.Base(path)
-		if base == ".git" || base == "vendor" || base == "node_modules" {
+		if base == ".git" || base == "vendor" || base == "node_modules" || base == ".idea" {
 			return filepath.SkipDir
 		}
 


### PR DESCRIPTION
Fixes #56 by adding .idea directory to skipped directories for Builder.

