### PR TITLE
Add `--prefix` flag to solve issue with init order

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,31 @@ Why do you want to do this? Packr first looks to the information stored in these
 
 ---
 
+## Usage in `init`
+
+There is a issue that *might* arise when using `Box` inside an `init` function, like so:
+
+```go
+func init() {
+	box := packr.NewBox("./files")
+}
+```
+
+This is due to `packr` also using the `init` function. Since Go runs the `init` functions in the order of the files that are passed to it, if your file that uses the `init` function comes after the `*-packr.go` file in alphabetical order, `packr` will not work as expected.
+
+### Fix
+
+A simple fix for this is to use the `--prefix` or `-p` flag to add a `a_` prefix to the generated file names.
+
+```bash
+# Generated files would be a_*-packr.go
+$ packr -p a_
+```
+
+This would place the generated files before your other files in alphabetical order, thus solving the problem.
+
+---
+
 ## Debugging
 
 The `packr` command passes all arguments down to the underlying `go` command, this includes the `-v` flag to print out `go build` information. Packr looks for the `-v` flag, and will turn on its own verbose logging. This is very useful for trying to understand what the `packr` command is doing when it is run.

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -32,6 +32,7 @@ type Builder struct {
 	pkgs           map[string]pkg
 	moot           *sync.Mutex
 	Compress       bool
+	Prefix         string
 }
 
 // Run the builder.
@@ -70,7 +71,7 @@ func (b *Builder) Run() error {
 
 func (b *Builder) dump() error {
 	for _, p := range b.pkgs {
-		name := filepath.Join(p.Dir, "a_"+p.Name+"-packr.go")
+		name := filepath.Join(p.Dir, b.Prefix+p.Name+"-packr.go")
 		f, err := os.Create(name)
 		defer f.Close()
 		if err != nil {

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -19,10 +19,10 @@ func Test_Builder_Run(t *testing.T) {
 	root := filepath.Join("..", "example")
 	defer Clean(root)
 
-	exPackr := filepath.Join(root, "a_example-packr.go")
+	exPackr := filepath.Join(root, "example-packr.go")
 	r.False(fileExists(exPackr))
 
-	fooPackr := filepath.Join(root, "foo", "a_foo-packr.go")
+	fooPackr := filepath.Join(root, "foo", "foo-packr.go")
 	r.False(fileExists(fooPackr))
 
 	b := New(context.Background(), root)
@@ -51,10 +51,10 @@ func Test_Builder_Run_Compress(t *testing.T) {
 	root := filepath.Join("..", "example")
 	defer Clean(root)
 
-	exPackr := filepath.Join(root, "a_example-packr.go")
+	exPackr := filepath.Join(root, "example-packr.go")
 	r.False(fileExists(exPackr))
 
-	fooPackr := filepath.Join(root, "foo", "a_foo-packr.go")
+	fooPackr := filepath.Join(root, "foo", "foo-packr.go")
 	r.False(fileExists(fooPackr))
 
 	b := New(context.Background(), root)
@@ -75,6 +75,39 @@ func Test_Builder_Run_Compress(t *testing.T) {
 	r.True(bytes.Contains(bb, []byte(`packr.PackJSONBytes("../assets", "app.css", "\"H4sIAAAAAAAA/0rKT`)))
 	r.True(bytes.Contains(bb, []byte(`packr.PackJSONBytes("../assets", "app.js", "\"H4sIAAAAAAAA/0rMSS`)))
 	r.True(bytes.Contains(bb, []byte(`packr.PackJSONBytes("../templates", "index.html", "\"H4sIAAAAAAAA`)))
+}
+
+func Test_Builder_Run_Prefix(t *testing.T) {
+	r := require.New(t)
+
+	root := filepath.Join("..", "example")
+	defer Clean(root)
+
+	exPackr := filepath.Join(root, "a_example-packr.go")
+	r.False(fileExists(exPackr))
+
+	fooPackr := filepath.Join(root, "foo", "a_foo-packr.go")
+	r.False(fileExists(fooPackr))
+
+	b := New(context.Background(), root)
+	b.Prefix = "a_"
+	err := b.Run()
+	r.NoError(err)
+
+	r.True(fileExists(exPackr))
+	r.True(fileExists(fooPackr))
+
+	bb, err := ioutil.ReadFile(exPackr)
+	r.NoError(err)
+	r.True(bytes.Contains(bb, []byte(`packr.PackJSONBytes("./assets", "app.css", "\"Ym9ke`)))
+	r.True(bytes.Contains(bb, []byte(`packr.PackJSONBytes("./assets", "app.js", "\"YWxlcn`)))
+	r.True(bytes.Contains(bb, []byte(`packr.PackJSONBytes("./templates", "index.html", "\"PCFET0NUWVBF`)))
+
+	bb, err = ioutil.ReadFile(fooPackr)
+	r.NoError(err)
+	r.True(bytes.Contains(bb, []byte(`packr.PackJSONBytes("../assets", "app.css", "\"Ym9keS`)))
+	r.True(bytes.Contains(bb, []byte(`packr.PackJSONBytes("../assets", "app.js", "\"YWxlcn`)))
+	r.True(bytes.Contains(bb, []byte(`packr.PackJSONBytes("../templates", "index.html", "\"PCFET0NUW`)))
 }
 
 func Test_Binary_Builds(t *testing.T) {

--- a/packr/cmd/root.go
+++ b/packr/cmd/root.go
@@ -11,6 +11,7 @@ import (
 
 var input string
 var compress bool
+var prefix string
 var verbose bool
 
 var rootCmd = &cobra.Command{
@@ -36,6 +37,7 @@ var rootCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		b := builder.New(context.Background(), input)
 		b.Compress = compress
+		b.Prefix = prefix
 		return b.Run()
 	},
 }
@@ -44,6 +46,7 @@ func init() {
 	pwd, _ := os.Getwd()
 	rootCmd.Flags().StringVarP(&input, "input", "i", pwd, "path to scan for packr Boxes")
 	rootCmd.Flags().BoolVarP(&compress, "compress", "z", false, "compress box contents")
+	rootCmd.Flags().StringVarP(&prefix, "prefix", "p", "", "prefix before generated file names")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "print verbose logging information")
 }
 


### PR DESCRIPTION
Solves #71 in a less hacky way.

Instead of adding a `a_` prefix for all `packr` generated files, we can instead give users the control by adding a `--prefix` flag, where they can specify the prefix `a_` to achieve the same result.

This will be useful since not many users have run into the issue, and this would reduce the effect that the change has on their code.

To inform others who run into this problem, a new section has also been added into the `README.md` detailing the problem and this solution.