### PR TITLE
Make generated files comply with gofmt

### DIFF
--- a/builder/tmpl.go
+++ b/builder/tmpl.go
@@ -11,7 +11,7 @@ import "github.com/gobuffalo/packr"
 func init() {
 	{{- range $box := .Boxes }}
 	{{- range .Files }}
-		packr.PackJSONBytes("{{$box.Name}}", "{{.Name}}", "{{.Contents}}")
+	packr.PackJSONBytes("{{$box.Name}}", "{{.Name}}", "{{.Contents}}")
 	{{- end }}
 	{{- end }}
 }


### PR DESCRIPTION
The generated files contained an extra tab character before every instance of `packr.PackJSONBytes`. This removes the extra tab such that the generated files are compliant with gofmt.