### PR TITLE
Fix issue with an ignored name being a file.

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -52,7 +52,11 @@ func (b *Builder) Run() error {
 		}
 		for _, f := range b.IgnoredFolders {
 			if strings.ToLower(f) == base {
-				return filepath.SkipDir
+				if info.IsDir() {
+					return filepath.SkipDir
+				} else {
+					return nil
+				}
 			}
 		}
 		if !info.IsDir() {


### PR DESCRIPTION
When packr is run in a git submodule, where `.git` is a file containing just a line
```
gitdir: ../.git/modules/my-sub-module
```
it causes an error during `filepath.Walk`, because it tries to return `SkipDir`, whereas the entry is a file but not a dir. In that case, we should instead return nil, so that the walk will move on to another file. If it returns `SkipDir`, the entire walk will fail with an error, and subsequent files and/or directories will all be ignored.