### PR TITLE
Fix an issue with conflicting directory names leading to box created in wrong folders.

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -150,7 +150,7 @@ func (b *Builder) process(path string) error {
 func (b *Builder) addPkg(p pkg) {
 	b.moot.Lock()
 	defer b.moot.Unlock()
-	key := filepath.Join(p.Dir[len(b.RootPath) + 1:], p.Name)
+	key := filepath.Join(p.Dir, p.Name)
 	if _, ok := b.pkgs[key]; !ok {
 		b.pkgs[key] = p
 		return

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -150,13 +150,14 @@ func (b *Builder) process(path string) error {
 func (b *Builder) addPkg(p pkg) {
 	b.moot.Lock()
 	defer b.moot.Unlock()
-	if _, ok := b.pkgs[p.Name]; !ok {
-		b.pkgs[p.Name] = p
+	key := filepath.Join(p.Dir[len(b.RootPath) + 1:], p.Name)
+	if _, ok := b.pkgs[key]; !ok {
+		b.pkgs[key] = p
 		return
 	}
-	pp := b.pkgs[p.Name]
+	pp := b.pkgs[key]
 	pp.Boxes = append(pp.Boxes, p.Boxes...)
-	b.pkgs[p.Name] = pp
+	b.pkgs[key] = pp
 }
 
 // New Builder with a given context and path


### PR DESCRIPTION
The case is this. In my application, from the root, I have a directory `config/...`, as well as `build/another-project/config/...`. It so happens that both config directories contain boxes.

Without this bugfix, packr would put both packages under the `config` key in the builder. It would just append the box of the second directory (where order is somewhat arbitrary) to the first package. However, the full directory of the second package is lost. In the end, we end up with a single package under the `config` key, with two boxes, both generated in one of the two directories. Obviously, the Go code in the other directory would not be able to load the contents from its box properly.

I'm changing this by using the full path. There will be separate packages, each containing a single box, assigned to those keys. Therefore, the code will be generated at the right place.

Please take a look. Thanks!