### PR TITLE
Add sections in README about portable releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,59 @@ Why do you want to do this? Packr first looks to the information stored in these
 
 ---
 
+## Building/Moving a portable release
+
+When it comes to building multiple releases you typically want that release to be built in a specific directory.
+
+For example: `./releases`
+
+Traditionally you would use the `-o` flag to tell `go` where to compile said release.
+
+However, because of how boxes work, we must compile the release in the appropriate absolute path.
+
+```bash
+GOOS=linux GOARCH=amd64 packr build
+```
+
+Now your `project_name` binary will be built at the root of your project dir. Great!
+
+All that is left to do is to move that binary to your release dir:
+
+Linux/macOS/Windows (bash)
+
+```bash
+mv ./project_name ./releases
+```
+
+Windows (cmd): 
+
+```cmd
+move ./project_name ./releases
+```
+
+Powershell:
+
+```powershell
+Move-Item -Path .\project_name -Destination .\releases\
+```
+
+If you _target_ for Windows when building don't forget that it's `project_name.exe`
+
+Now you can make multiple releases and all of your needed static files will be available!
+
+#### Summing it up:
+
+Example Script for building to 3 common targets:
+
+```bash
+GOOS=darwin GOARCH=amd64 packr build && mv ./project_name ./releases/darwin-project_name \
+  && GOOS=linux GOARCH=amd64 packr build && mv ./project_name ./releases/linux-project_name \
+  && GOOS=windows GOARCH=386 packr build && mv ./project_name.exe ./releases/project_name.exe \
+  && packr clean
+```
+
+---
+
 ## Debugging
 
 The `packr` command passes all arguments down to the underlying `go` command, this includes the `-v` flag to print out `go build` information. Packr looks for the `-v` flag, and will turn on its own verbose logging. This is very useful for trying to understand what the `packr` command is doing when it is run.

--- a/README.md
+++ b/README.md
@@ -146,9 +146,7 @@ When it comes to building multiple releases you typically want that release to b
 
 For example: `./releases`
 
-Traditionally you would use the `-o` flag to tell `go` where to compile said release.
-
-However, because of how boxes work, we must compile the release in the appropriate absolute path.
+However, because passing a `.go` file requires absolute paths, we must compile the release in the appropriate absolute path.
 
 ```bash
 GOOS=linux GOARCH=amd64 packr build


### PR DESCRIPTION
# Portability

I have updated the README about how to cover certain use cases.

This references #75 as well as #85 

🙏 

### Problem

Compiling with `.go` files requires absolute paths

Having multiple releases in a directory is problematic

### Solution

Using `mv` to move the built binary without the `-o` flag to the target dir mitigates said issues.
