### PR TITLE
Reject, early on, a directory that can't have any Go files accepted a…

### DIFF
--- a/v2/jam/parser/roots.go
+++ b/v2/jam/parser/roots.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -55,6 +56,11 @@ func NewFromRoots(roots []string, opts *RootsOptions) (*Parser, error) {
 	}
 	for _, root := range roots {
 		plog.Debug(p, "NewFromRoots", "walking", root)
+		sample := filepath.Join(root, "sample.go")
+		if !IsProspect(sample) {
+			fmt.Fprintf(os.Stderr, "Directory not a prospect due to ignored component(s): %s\n", root)
+			continue
+		}
 		err := godirwalk.Walk(root, wopts)
 		if err != nil {
 			return p, errors.WithStack(err)


### PR DESCRIPTION
…s prospects.

This also warns the user for such cases (several times, it seems; not
sure why the dir-walking code is invoked more than once).

Note that a workaround for having e.g. `.go/` as a component in the
path to Go source tree being "packed" is, for example:

```
$ packr2 -- .
$ go build
```

Even though there will still be warnings, `.` as an explicit directory
name will (as confirmed by the `-v` option) pick up `.go` files as
legitimate prospects, because the full path is not included in the
prospect check(s).