### PR TITLE
Fix Box.Open to not generate virtual dirs that don't exist

### DIFF
--- a/v2/box.go
+++ b/v2/box.go
@@ -166,14 +166,14 @@ func (b Box) Has(name string) bool {
 // Open returns a File using the http.File interface
 func (b Box) Open(name string) (http.File, error) {
 	plog.Debug(b, "Open", "name", name)
+	f, err := b.Resolve(name)
+	if err != nil {
+		return f, err
+	}
 	if len(filepath.Ext(name)) == 0 {
 		d, err := file.NewDir(name)
 		plog.Debug(b, "Open", "name", name, "dir", d)
 		return d, err
-	}
-	f, err := b.Resolve(name)
-	if err != nil {
-		return f, err
 	}
 	f, err = file.NewFileR(name, f)
 	plog.Debug(b, "Open", "name", f.Name(), "file", f.Name())

--- a/v2/box.go
+++ b/v2/box.go
@@ -167,7 +167,9 @@ func (b Box) Has(name string) bool {
 func (b Box) Open(name string) (http.File, error) {
 	plog.Debug(b, "Open", "name", name)
 	f, err := b.Resolve(name)
-	if err != nil {
+	// Some resolvers don't resolve empty directories,
+	// but net/http/fs.go expects it
+	if err != nil && name[len(name)-1] != '/' {
 		return f, err
 	}
 	if len(filepath.Ext(name)) == 0 {

--- a/v2/box_test.go
+++ b/v2/box_test.go
@@ -195,6 +195,10 @@ func Test_Box_Open(t *testing.T) {
 	f, err = box.Open("idontexist.txt")
 	r.Error(err)
 	r.Zero(f)
+
+	f, err = box.Open("dirdoesntexit")
+	r.Error(err)
+	r.Zero(f)
 }
 
 func Test_Box_List(t *testing.T) {


### PR DESCRIPTION
See https://github.com/gobuffalo/buffalo/issues/1524#issuecomment-451704883 for more information.

In my opinion, packr should first check if the directory exists and then create a virtual directory for it.