### PR TITLE
Issue-154: unclosed gzip.Reader

### DIFF
--- a/box.go
+++ b/box.go
@@ -129,6 +129,8 @@ func (b Box) decompress(bb []byte) []byte {
 	if err != nil {
 		return bb
 	}
+	defer reader.Close()
+
 	data, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return bb


### PR DESCRIPTION
Fixes: https://github.com/gobuffalo/packr/issues/154

Adds a deferred close to the `gzip.Reader` to avoid file descriptor leak.