### PR TITLE
Revert "box.Open: Do not call file.NewFileR when IsDir true, fix #198"

### DIFF
--- a/v2/box.go
+++ b/v2/box.go
@@ -15,8 +15,8 @@ import (
 	"github.com/gobuffalo/packd"
 	"github.com/gobuffalo/packr/v2/file"
 	"github.com/gobuffalo/packr/v2/file/resolver"
-	"github.com/gobuffalo/packr/v2/internal/takeon/github.com/markbates/oncer"
 	"github.com/gobuffalo/packr/v2/plog"
+	"github.com/gobuffalo/packr/v2/internal/takeon/github.com/markbates/oncer"
 )
 
 var _ packd.Box = &Box{}
@@ -28,12 +28,12 @@ var _ packd.Finder = &Box{}
 // Box represent a folder on a disk you want to
 // have access to in the built Go binary.
 type Box struct {
-	Path            string            `json:"path"`
-	Name            string            `json:"name"`
-	ResolutionDir   string            `json:"resolution_dir"`
-	DefaultResolver resolver.Resolver `json:"default_resolver"`
-	resolvers       resolversMap
-	dirs            dirsMap
+	Path		string			`json:"path"`
+	Name		string			`json:"name"`
+	ResolutionDir	string			`json:"resolution_dir"`
+	DefaultResolver	resolver.Resolver	`json:"default_resolver"`
+	resolvers	resolversMap
+	dirs		dirsMap
 }
 
 // NewBox returns a Box that can be used to
@@ -125,9 +125,6 @@ func (b *Box) Has(name string) bool {
 
 // HasDir returns true if the directory exists in the box
 func (b *Box) HasDir(name string) bool {
-	if name == "/" {
-		return b.Has("index.html")
-	}
 	oncer.Do("packr2/box/HasDir"+b.Name, func() {
 		for _, f := range b.List() {
 			for d := filepath.Dir(f); d != "."; d = filepath.Dir(d) {
@@ -135,6 +132,9 @@ func (b *Box) HasDir(name string) bool {
 			}
 		}
 	})
+	if name == "/" {
+		return b.Has("index.html")
+	}
 	_, ok := b.dirs.Load(name)
 	return ok
 }
@@ -149,13 +149,7 @@ func (b *Box) Open(name string) (http.File, error) {
 		}
 		return f, err
 	}
-	info, err := f.FileInfo()
-	if err != nil {
-		return f, err
-	}
-	if !info.IsDir() {
-		f, err = file.NewFileR(name, f)
-	}
+	f, err = file.NewFileR(name, f)
 	plog.Debug(b, "Open", "name", f.Name(), "file", f.Name())
 	return f, err
 }

--- a/v2/box_test.go
+++ b/v2/box_test.go
@@ -190,30 +190,10 @@ func Test_Box_Open(t *testing.T) {
 
 	box.DefaultResolver = d
 
-	type pathTest struct {
-		path  string
-		isDir bool
-	}
-
-	pathTests := []pathTest{
-		{"foo.txt", false},
-		{"/foo.txt", false},
-		{"bar", false},
-		{"/bar", false},
-		{"baz", true},
-		{"/baz", true},
-		{"baz/index.html", false},
-		{"/baz/index.html", false},
-	}
-
-	for _, x := range pathTests {
-		f, err := box.Open(x.path)
-		r.NoError(err, "for path %#v", x.path)
-		r.NotZero(f, "for path %#v", x.path)
-
-		stat, err := f.Stat()
-		r.NoError(err, "for path %#v", x.path)
-		r.Equal(x.isDir, stat.IsDir(), "stat.IsDir() != %t for path %#v", true, x.path)
+	for _, x := range []string{"foo.txt", "/foo.txt", "bar", "/bar", "baz", "/baz"} {
+		f, err := box.Open(x)
+		r.NoError(err)
+		r.NotZero(f)
 	}
 
 	f, err := box.Open("idontexist.txt")


### PR DESCRIPTION
When running the tests locally I keep getting the following error. I'm reverting this PR until the tests pass cleanly.

```
--- FAIL: Test_Box_Open (0.00s)
    require.go:157: 
        	Error Trace:	box_test.go:216
        	Error:      	Not equal: 
        	            	expected: true
        	            	actual  : false
        	Test:       	Test_Box_Open
        	Messages:   	stat.IsDir() != true for path "/baz"
```