### PR TITLE
Check for `go.mod` when searching for files.

### DIFF
--- a/v2/jam/parser/finder.go
+++ b/v2/jam/parser/finder.go
@@ -84,8 +84,11 @@ func (fd *finder) findAllGoFilesImports(dir string) ([]string, error) {
 		if pkg.Goroot {
 			return
 		}
-		if len(pkg.GoFiles) <= 0 {
-			return
+
+		if _, err := os.Stat(pkg.Dir + "/go.mod"); err != nil {
+			if len(pkg.GoFiles) <= 0 {
+				return
+			}
 		}
 
 		plog.Debug(fd, "findAllGoFilesImports", "dir", dir)


### PR DESCRIPTION
It appears that `GoFiles` from [`Package`](https://godoc.org/go/build#Package) is _NOT_ module aware. Therefore the check in `v2/jam/parser/finder.go:87` would always return
and not find files. The only way in which I think we can reliably check
if a project is using modules is to check for the presence of `go.mod`
in the package root. Thus, I have added the guard to check for `go.mod`
before we rely on `pkg.GoFiles`.

This should address #195 and #228