### PR TITLE
Change default resolver behavior

### DIFF
--- a/v2/box.go
+++ b/v2/box.go
@@ -186,7 +186,7 @@ func (b *Box) List() []string {
 }
 
 // Resolve will attempt to find the file in the box,
-// returning an error if the find can not be found.
+// returning an error if the file can not be found.
 func (b *Box) Resolve(key string) (file.File, error) {
 	key = strings.TrimPrefix(key, "/")
 

--- a/v2/helpers.go
+++ b/v2/helpers.go
@@ -7,16 +7,24 @@ import (
 	"strings"
 
 	"github.com/gobuffalo/envy"
+	"github.com/gobuffalo/packr/v2/file/resolver"
 	"github.com/gobuffalo/packr/v2/plog"
 )
 
 func construct(name string, path string) *Box {
+	var dr resolver.Resolver
+	rd := resolutionDir(path)
+	if len(rd) > 0 {
+		dr = &resolver.Disk{Root: resolver.OsPath(rd)}
+	}
+
 	return &Box{
-		Path:		path,
-		Name:		name,
-		ResolutionDir:	resolutionDir(path),
-		resolvers:	resolversMap{},
-		dirs:		dirsMap{},
+		Path:            path,
+		Name:            name,
+		ResolutionDir:   rd,
+		DefaultResolver: dr,
+		resolvers:       resolversMap{},
+		dirs:            dirsMap{},
 	}
 }
 
@@ -49,12 +57,6 @@ func resolutionDirExists(s, og string) bool {
 }
 
 func resolutionDir(og string) string {
-	ng, _ := filepath.Abs(og)
-
-	if resolutionDirExists(ng, og) {
-		return ng
-	}
-
 	// packr.New
 	_, filename, _, _ := runtime.Caller(3)
 	ng, ok := resolutionDirTestFilename(filename, og)
@@ -69,5 +71,5 @@ func resolutionDir(og string) string {
 		return ng
 	}
 
-	return og
+	return ""
 }

--- a/v2/walk.go
+++ b/v2/walk.go
@@ -18,15 +18,12 @@ func (b *Box) Walk(wf WalkFunc) error {
 	m := map[string]file.File{}
 
 	dr := b.DefaultResolver
-	if dr == nil {
-		cd := resolver.OsPath(b.ResolutionDir)
-		dr = &resolver.Disk{Root: cd}
-	}
 	if fm, ok := dr.(file.FileMappable); ok {
 		for n, f := range fm.FileMap() {
 			m[n] = f
 		}
 	}
+
 	var err error
 	b.resolvers.Range(func(n string, r resolver.Resolver) bool {
 		var f file.File


### PR DESCRIPTION
This is an attempt to solve the problem from #222
In its previous version, packr2 used the current working directory as
its default disk resolver. This commit tries to use the development
directory instead.

---

I'm not sure about this PR, it may need some additional testing :)