### PR TITLE
Print version on new line

### DIFF
--- a/packr/cmd/version.go
+++ b/packr/cmd/version.go
@@ -11,7 +11,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "prints packr version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Print(packr.Version)
+		fmt.Println(packr.Version)
 	},
 }
 

--- a/v2/packr2/cmd/version.go
+++ b/v2/packr2/cmd/version.go
@@ -11,7 +11,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "shows packr version",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Print(packr.Version)
+		fmt.Println(packr.Version)
 		return nil
 	},
 }


### PR DESCRIPTION
When running `packr version`, it should print the version on it's own line.

Current behavior:
```
$ packr version
v2.5.3$
```

New behavior:
```
$ packr version
v2.5.3
$
```

When checking the recommended behavior against [Cobra](https://github.com/spf13/cobra), their example uses `Println`, as well.
```
var versionCmd = &cobra.Command{
  Use:   "version",
  Short: "Print the version number of Hugo",
  Long:  `All software has versions. This is Hugo's`,
  Run: func(cmd *cobra.Command, args []string) {
    fmt.Println("Hugo Static Site Generator v0.9 -- HEAD")
  },
}
```