### PR TITLE
README: linkify migration target suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**NOTICE: Please consider migrating your projects to github.com/markbates/pkger. It has an idiomatic API, minimal dependencies, a stronger test suite (tested directly against the std lib counterparts), transparent tooling, and more.**
+**NOTICE: Please consider migrating your projects to [github.com/markbates/pkger](https://github.com/markbates/pkger). It has an idiomatic API, minimal dependencies, a stronger test suite (tested directly against the std lib counterparts), transparent tooling, and more.**
 
 https://blog.gobuffalo.io/introducing-pkger-static-file-embedding-in-go-1ce76dc79c65
 


### PR DESCRIPTION
Makes `github.com/markbates/pkger` a link. Might save a click or two for folks on their way.