### PR TITLE
fix bug on resolving import path for diskImportTempl

### DIFF
--- a/v2/jam/store/disk.go
+++ b/v2/jam/store/disk.go
@@ -288,6 +288,9 @@ func (d *Disk) Close() error {
 		ip = filepath.Dir(d.DBPath)
 		srcs := internal.GoPaths()
 		srcs = append(srcs, build.Default.SrcDirs()...)
+		sort.SliceStable(srcs, func(i, j int) bool {
+			return len(srcs[i]) > len(srcs[j])
+		})
 		for _, x := range srcs {
 			ip = strings.TrimPrefix(ip, "/private")
 			ip = strings.TrimPrefix(ip, x)


### PR DESCRIPTION
My GOPATH is`/home/jsteuer/go:/home/jsteuer/go_dev`. If I run packr2 the generated `*-packr.go` contains the following bad import.

    // +build !skippackr
    // Code generated by github.com/gobuffalo/packr/v2. DO NOT EDIT.

    // You can use the "packr clean" command to clean up this,
    // and any other packr generated files.
    package template_index

    import _ "_dev/src/github.com/jsteuer/myproject/packrd"

Because both paths are sharing the substring `/home/jsteuer/go` the algorithm to calculate the `.Import` path for `diskImportTempl` is depending on the order of the GOPATH. (If `GO111MODULE=on` the problem does not appears - thanks to #183). I think this is bug, so sorting the entries of the GOPATH solves this issue for me:

    // +build !skippackr
    // Code generated by github.com/gobuffalo/packr/v2. DO NOT EDIT.

    // You can use the "packr clean" command to clean up this,
    // and any other packr generated files.
    package template_index

    import _ "github.com/jsteuer/myproject/packrd"

