### PR TITLE
Always accept initial path

### DIFF
--- a/v2/jam/parser/prospect.go
+++ b/v2/jam/parser/prospect.go
@@ -11,11 +11,11 @@ import (
 
 var DefaultIgnoredFolders = []string{".", "_", "vendor", "node_modules", "_fixtures", "testdata"}
 
-func IsProspect(path string, ignore ...string) (status bool) {
+func IsProspect(root string, path string, ignore ...string) (status bool) {
 	// plog.Debug("parser", "IsProspect", "path", path, "ignore", ignore)
 	defer func() {
 		if status {
-			plog.Debug("parser", "IsProspect (TRUE)", "path", path, "status", status)
+			plog.Debug("parser", "IsProspect (TRUE)", "root", root, "path", path, "status", status)
 		}
 	}()
 	if path == "." {
@@ -52,10 +52,7 @@ func IsProspect(path string, ignore ...string) (status bool) {
 		ignore[i] = strings.TrimSpace(strings.ToLower(x))
 	}
 
-	parts := strings.Split(resolver.OsPath(path), string(filepath.Separator))
-	if len(parts) == 0 {
-		return false
-	}
+	parts := partsUnderRoot(root, path)
 
 	for _, i := range ignore {
 		for _, p := range parts {
@@ -74,4 +71,23 @@ func IsProspect(path string, ignore ...string) (status bool) {
 	}
 
 	return ext == ".go"
+}
+
+func partsUnderRoot(root string, path string) []string {
+	root = filepath.Clean(resolver.OsPath(root))
+	path = filepath.Clean(resolver.OsPath(path))
+	rootParts := strings.Split(root, string(filepath.Separator))
+	pathParts := strings.Split(path, string(filepath.Separator))
+
+	if len(rootParts) > len(pathParts) {
+		rootParts = rootParts[:len(pathParts)]
+	}
+
+	for i, r := range rootParts {
+		if pathParts[i] != r {
+			return pathParts[i:]
+		}
+	}
+
+	return pathParts[len(rootParts):]
 }

--- a/v2/jam/parser/prospect_test.go
+++ b/v2/jam/parser/prospect_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -8,30 +9,37 @@ import (
 
 func Test_IsProspect(t *testing.T) {
 	table := []struct {
+		root string
 		path string
 		pass bool
 	}{
-		{"foo/.git/config", false},
-		{"foo/.git/baz.go", false},
-		{"a.go", true},
-		{".", true},
-		{"a/b.go", true},
-		{"a/b_test.go", false},
-		{"a/b-packr.go", false},
-		{"a/vendor/b.go", false},
-		{"a/_c/c.go", false},
-		{"a/_c/e/fe/f/c.go", false},
-		{"a/d/_d.go", false},
-		{"a/d/", false},
+		{"", "foo/.git/config", false},
+		{"", "foo/.git/baz.go", false},
+		{"", "a.go", true},
+		{"", ".", true},
+		{"", "a/b.go", true},
+		{"", "a/b_test.go", false},
+		{"", "a/b-packr.go", false},
+		{"", "a/vendor/b.go", false},
+		{"", "a/_c/c.go", false},
+		{"", "a/_c/e/fe/f/c.go", false},
+		{"", "a/d/_d.go", false},
+		{"", "a/d/", false},
+		{".", ".", true},
+		{"a", "a/b.go", true},
+		{"a/vendor", "a/vendor/b.go", true},
+		{"a", "a/vendor/b.go", false},
+		{".ci", ".ci/a/b.go", true},
+		{"a", "a/.ci/b.go", false},
 	}
 
 	for _, tt := range table {
-		t.Run(tt.path, func(st *testing.T) {
+		t.Run(fmt.Sprintf("%s:%s", tt.root, tt.path), func(st *testing.T) {
 			r := require.New(st)
 			if tt.pass {
-				r.True(IsProspect(tt.path, ".", "_"))
+				r.True(IsProspect(tt.root, tt.path, ".", "_"))
 			} else {
-				r.False(IsProspect(tt.path, ".", "_"))
+				r.False(IsProspect(tt.root, tt.path, ".", "_"))
 			}
 		})
 	}

--- a/v2/jam/parser/roots.go
+++ b/v2/jam/parser/roots.go
@@ -35,25 +35,25 @@ func NewFromRoots(roots []string, opts *RootsOptions) (*Parser, error) {
 	}
 	p := New()
 	plog.Debug(p, "NewFromRoots", "roots", roots, "options", opts)
-	callback := func(path string, de *godirwalk.Dirent) error {
-		if IsProspect(path, opts.Ignores...) {
-			if de.IsDir() {
-				return nil
-			}
-			roots = append(roots, path)
-			return nil
-		}
-		if de.IsDir() {
-			return filepath.SkipDir
-		}
-		return nil
-	}
-	wopts := &godirwalk.Options{
-		FollowSymbolicLinks: true,
-		Callback:            callback,
-	}
 	for _, root := range roots {
 		plog.Debug(p, "NewFromRoots", "walking", root)
+		callback := func(path string, de *godirwalk.Dirent) error {
+			if IsProspect(root, path, opts.Ignores...) {
+				if de.IsDir() {
+					return nil
+				}
+				roots = append(roots, path)
+				return nil
+			}
+			if de.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		wopts := &godirwalk.Options{
+			FollowSymbolicLinks: true,
+			Callback:            callback,
+		}
 		err := godirwalk.Walk(root, wopts)
 		if err != nil {
 			return p, err
@@ -70,7 +70,7 @@ func NewFromRoots(roots []string, opts *RootsOptions) (*Parser, error) {
 			names, _ = fd.findAllGoFilesImports(r)
 		}
 		for _, n := range names {
-			if IsProspect(n) {
+			if IsProspect(n, n) {
 				plog.Debug(p, "NewFromRoots", "mapping", n)
 				dd[n] = n
 			}


### PR DESCRIPTION
Always accept the path that packr2 should work on, even if it contains ignored path segments.
Ignore prefixes continue to work as before, but only for sub paths.

This enables the use of packr2 in CI builds where the project is placed in a temporary location for building, which contains '.' or '_' prefix.