### PR TITLE
Fix a typo in README: FindBytes -> Find

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ box := packr.NewBox("./templates")
 html, err := box.FindString("index.html")
 
 // Get the []byte representation of a file, or an error if it doesn't exist:
-html, err := box.FindBytes("index.html")
+html, err := box.Find("index.html")
 ```
 
 ### What is a Box?


### PR DESCRIPTION
There is no such a `FindBytes` method implemented for `Box`. I suppose it should be `Find`, according to:
https://github.com/gobuffalo/packr/blob/c6a5045204dacffbe11d9f6c68485ae7e7fe3d19/box_test.go#L27