### PR TITLE
Adding s390x Support

### DIFF
--- a/v2/.goreleaser.yml.plush
+++ b/v2/.goreleaser.yml.plush
@@ -5,6 +5,7 @@ builds:
     - linux
     - windows
   goarch:
+    - s390x
     - ppc64le
     - 386
     - amd64
@@ -15,6 +16,10 @@ builds:
       goarch: ppc64le
     - goos: windows
       goarch: ppc64le
+    - goos: darwin
+      goarch: s390x
+    - goos: windows
+      goarch: s390x
   main: ./packr2/main.go
   binary: packr2
 


### PR DESCRIPTION
This PR allows binaries to be built for `s390x`. Just like `ppc64le`, `s390x` does not have Windows or Darwin support. 

@markbates and @stanislas-m let me know if you have any questions!