### PR TITLE
fixed readme and version bump up

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 1
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
       - name: Test
         run: |
-          go test -race ./...
+          go test -race -cover -v ./...
           go install -v ./packr2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-**NOTICE: Please consider migrating your projects to github.com/markbates/pkger. It has an idiomatic API, minimal dependencies, a stronger test suite (tested directly against the std lib counterparts), transparent tooling, and more.**
+**NOTICE: Please consider migrating your projects to
+[embed](https://pkg.go.dev/embed) which is native file embedding feature of Go,
+or github.com/markbates/pkger. It has an idiomatic API, minimal dependencies, a stronger test suite (tested directly against the std lib counterparts), transparent tooling, and more.**
 
 https://blog.gobuffalo.io/introducing-pkger-static-file-embedding-in-go-1ce76dc79c65
 
@@ -9,20 +11,55 @@ https://blog.gobuffalo.io/introducing-pkger-static-file-embedding-in-go-1ce76dc7
 
 Packr is a simple solution for bundling static assets inside of Go binaries. Most importantly it does it in a way that is friendly to developers while they are developing.
 
+At this moment, supported go versions are:
+
+* 1.16.x
+* 1.17.x
+
+even though it may (or may not) working well with older versions.
+
 ## Intro Video
 
 To get an idea of the what and why of Packr, please enjoy this short video: [https://vimeo.com/219863271](https://vimeo.com/219863271).
 
 ## Library Installation
 
-```text
-$ go get -u github.com/gobuffalo/packr/v2/...
+### Go 1.16 and above
+
+```console
+$ go install github.com/gobuffalo/packr/v2@v2.8.3
+```
+
+or
+
+```console
+$ go install github.com/gobuffalo/packr/v2@latest
+```
+
+### Go 1.15 and below
+
+```console
+$ go get -u github.com/gobuffalo/packr/...
 ```
 
 ## Binary Installation
 
-```text
-$ go get -u github.com/gobuffalo/packr/v2/packr2
+### Go 1.16 and above
+
+```console
+$ go install github.com/gobuffalo/packr/v2/packr2@v2.8.3
+```
+
+or
+
+```console
+$ go install github.com/gobuffalo/packr/v2/packr2@latest
+```
+
+### Go 1.15 and below
+
+```console
+$ go get -u github.com/gobuffalo/packr/packr2
 ```
 
 ## New File Format FAQs

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package packr
 
 // Version of Packr
-const Version = "v2.8.1"
+const Version = "v2.8.3"


### PR DESCRIPTION
Updated README.md and version bump up. (previous release 2.8.2 still prints 2.8.1)

fixes #296